### PR TITLE
Make serde optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.5
+### API Changes
+- Make serde an optional, default feature
+
 ## v0.3.4
 ### Bugfixes
 - PauseEnds was called after load

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raplay"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "GPL-3.0"
 description = "Library for playing audio"
@@ -16,6 +16,9 @@ categories = ["multimedia::audio"]
 anyhow = "1.0.75"
 cpal = "0.15.2"
 num = "0.4.1"
-serde = {version = "1.0.188", features = [ "std", "derive" ]}
+serde = { version = "1.0.188", features = ["std", "derive"], optional = true }
 symphonia = { version = "0.5.3", features = ["all"] }
 thiserror = "1.0.47"
+
+[features]
+default = ["serde"]

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,8 +1,10 @@
 use std::time::Duration;
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Timestamp {
     pub current: Duration,
     pub total: Duration,


### PR DESCRIPTION
Hello!

I'm looking to use this crate and I wanted `serde` to be optional. I'm unsure if I'll use this crate, or serde, but I thought I'd submit it upstream and let you decide if you wanted it or not. No big deal either way.

I have serde enabled by default as to hopefully not break any current users.

I also bumped the version to 0.3.5 and added an entry to the changelog. I classed it as an "API Change" but I'm not sure if that's correct.