### PR TITLE
Fix bug causing input devices to be selected instead of output

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -44,7 +44,7 @@ impl Sink {
         let mut device = self.device.take().map(|d| Ok(d)).unwrap_or_else(
             || -> Result<_> {
                 Ok(cpal::default_host()
-                    .default_input_device()
+                    .default_output_device()
                     .ok_or(Error::NoOutDevice)?)
             },
         )?;
@@ -53,7 +53,7 @@ impl Sink {
             c
         } else {
             device = cpal::default_host()
-                .default_input_device()
+                .default_output_device()
                 .ok_or(Error::NoOutDevice)?;
             device.supported_output_configs()?
         };
@@ -83,7 +83,10 @@ impl Sink {
                 device.build_output_stream(
                     &config,
                     move |d: &mut [$t], info| {
-                        mixer.mix(&mut SampleBufferMut::$e(d), get_play_time(info))
+                        mixer.mix(
+                            &mut SampleBufferMut::$e(d),
+                            get_play_time(info),
+                        )
                     },
                     move |e| {
                         _ = shared.invoke_err_callback(e.into());


### PR DESCRIPTION
Hello again!

This PR fixes the `sink.rs` file. I saw that there were two calls to  `.default_input_device()` on line 47 and 56. I changed those to `.default_output_device()` and the library started working for me :D

I did **not** modify the changelog or increase a patch version or anything.

This PR does **not** have the changes that #1 has. I don't know why I feel the need to say that, but I do. It should be trivial to merge, though *(no conflicts)*.

Hope you're having a good day :D